### PR TITLE
Update class-gpnf-session.php

### DIFF
--- a/includes/class-gpnf-session.php
+++ b/includes/class-gpnf-session.php
@@ -104,7 +104,7 @@ class GPNF_Session {
 	}
 
 	public function get_cookie_name() {
-		$name = implode( '_', array( self::COOKIE_NAME, $this->_form_id ) );
+		$name = array( self::COOKIE_NAME, $this->_form_id )[0].date("Y-m-d-h-i-s");
 		/**
 		 * Filter the name of the session cookie GPNF uses for a given form
 		 *


### PR DESCRIPTION
The array( self::COOKIE_NAME, $this->_form_id ) was an array of arrays hence was not getting converted into string by implode. Even running a for loop through each element did not work. So to remove the bug, I used the first element of the array and the current time and date to make it a unique cookie.